### PR TITLE
Supoprt env vars: SERVER_NAME, APP_SERVICE

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ php artisan sail-ssl:install
 
 After containers started, you can access https://localhost.
 
+## Environment variables
+- `SERVER_NAME`
+  - Determine `server_name` directive in nginx.conf
+  - Default: `localhost`
+- `APP_SERVICE`
+  - Specify Laravel container name in docker-compose.yml
+  - Default: `laravel.test`
+- `HTTP_PORT`
+  - Port to forward Nginx HTTP port
+  - By default, request for this port would redirect to `SSL_PORT`
+  - Default: `8000`
+- `SSL_PORT`
+  - Port to forward Nginx HTTPS port
+  - Default: `443`
+
 ## Configure Nginx
 `./nginx/templates/default.conf.template` will be published.
 ```sh

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,13 +1,13 @@
 server {
     listen  80  default_server;
-    server_name localhost;
+    server_name ${SERVER_NAME};
 
     return  301 https://$host:${SSL_PORT}$request_uri;
 }
 
 server {
     listen  443 ssl default_server;
-    server_name localhost;
+    server_name ${SERVER_NAME};
 
     # Self signed certificates
     # Don't use them in a production server!
@@ -15,6 +15,6 @@ server {
     ssl_certificate_key /etc/nginx/certs/server.key;
 
     location / {
-        proxy_pass	http://laravel.test;
+        proxy_pass	http://${APP_SERVICE};
     }
 }

--- a/stubs/nginx.stub
+++ b/stubs/nginx.stub
@@ -5,11 +5,13 @@
             - '${SSL_PORT:-443}:443'
         environment:
             - SSL_PORT=${SSL_PORT:-443}
+            - APP_SERVICE=${APP_SERVICE:-laravel.test}
+            - SERVER_NAME=${SERVER_NAME:-localhost}
         volumes:
             - 'sail-nginx:/etc/nginx/certs'
             - './vendor/ryoluo/sail-ssl/nginx/templates:/etc/nginx/templates'
             - './vendor/ryoluo/sail-ssl/nginx/generate-ssl-cert.sh:/docker-entrypoint.d/99-generate-ssl-cert.sh'
         depends_on:
-            - laravel.test
+            - ${APP_SERVICE:-laravel.test}
         networks:
             - sail


### PR DESCRIPTION
## Resolve https://github.com/ryoluo/sail-ssl/issues/3
Support following environment variables:
- `SERVER_NAME` 
  - Determine `server_name` directive in nginx.conf
  - Default: `localhost`
- `APP_SERVICE`
  - Specify Laravel container name in docker-compose.yml
  - Default: `laravel.test`