### PR TITLE
Forward proxy headers

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -15,6 +15,10 @@ server {
     ssl_certificate_key /etc/nginx/certs/server.key;
 
     location / {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_pass	http://${APP_SERVICE};
     }
 }


### PR DESCRIPTION
Hey!

Thanks for this package. I've recently used it on one of my projects and it works great. One issue I've noticed though is that the `URL` generator would use Sail's service base URL, e.g. `laravel.test`. I figured that passing through these additional headers and configuring `TrustProxies` where `$proxies = '*';` (or whatever the Sail host IP is) in Laravel will correctly propagate the `$_SERVER['REMOTE_ADDR']` and `URL` generator will create correct URLs.