### PR TITLE
Sail v1.46.0 compose.yaml compatibility

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -24,9 +24,14 @@ class InstallCommand extends Command
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
-        $dockerCompose = file_get_contents($this->laravel->basePath('docker-compose.yml'));
+        $dockerComposePath = $this->laravel->basePath('docker-compose.yml');
+        if (!file_exists($dockerComposePath)) {
+            $dockerComposePath = $this->laravel->basePath('compose.yaml');
+        }
+
+        $dockerCompose = file_get_contents($dockerComposePath);
         if (str_contains($dockerCompose, 'nginx:')) {
             $this->info('Nginx container is already installed. Do nothing.');
             return;
@@ -39,7 +44,7 @@ class InstallCommand extends Command
             ["services:\n{$nginxStub}", "volumes:\n{$volumeStub}"],
             $dockerCompose
         );
-        file_put_contents($this->laravel->basePath('docker-compose.yml'), $dockerCompose);
+        file_put_contents($dockerComposePath, $dockerCompose);
         $this->info('Nginx container successfully installed in Docker Compose.');
     }
 }

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -25,13 +25,22 @@ class PublishCommand extends Command
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
-        $dockerCompose = file_get_contents($this->laravel->basePath('docker-compose.yml'));
+        $dockerComposePath = $this->laravel->basePath('docker-compose.yml');
+        if (!file_exists($dockerComposePath)) {
+            $dockerComposePath = $this->laravel->basePath('compose.yaml');
+        }
+
+        $dockerCompose = file_get_contents($dockerComposePath);
         $this->call('vendor:publish', ['--tag' => 'sail-ssl']);
         file_put_contents(
-            $this->laravel->basePath('docker-compose.yml'),
-            str_replace('./vendor/ryoluo/sail-ssl/nginx/templates', './nginx/templates', $dockerCompose)
+            $dockerComposePath,
+            str_replace(
+                './vendor/ryoluo/sail-ssl/nginx/templates',
+                './nginx/templates',
+                $dockerCompose
+            )
         );
     }
 }

--- a/src/SailSslServiceProvider.php
+++ b/src/SailSslServiceProvider.php
@@ -14,7 +14,7 @@ class SailSslServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->registerCommands();
         $this->configurePublishing();
@@ -25,7 +25,7 @@ class SailSslServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return void
      */
-    protected function registerCommands()
+    protected function registerCommands(): void
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
@@ -40,7 +40,7 @@ class SailSslServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return void
      */
-    protected function configurePublishing()
+    protected function configurePublishing(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -54,7 +54,7 @@ class SailSslServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return array
      */
-    public function provides()
+    public function provides(): array
     {
         return [
             InstallCommand::class,

--- a/tests/Feature/PublishCommandTest.php
+++ b/tests/Feature/PublishCommandTest.php
@@ -10,7 +10,13 @@ class PublishCommandTest extends TestCase
     {
         $this->artisan('sail-ssl:install')->assertSuccessful();
         $this->artisan('sail-ssl:publish')->assertSuccessful();
-        $dockerCompose = file_get_contents($this->app->basePath('docker-compose.yml'));
+
+        $dockerCompose = $this->app->basePath('docker-compose.yml');
+        if (!file_exists($dockerCompose)) {
+            $dockerCompose = $this->app->basePath('compose.yaml');
+        }
+
+        $dockerCompose = file_get_contents($dockerCompose);
         $expectedLine = "- './nginx/templates:/etc/nginx/templates'";
         $this->assertTrue(str_contains($dockerCompose, $expectedLine));
         $this->assertTrue(file_exists($this->app->basePath('nginx/templates/default.conf.template')));
@@ -19,7 +25,11 @@ class PublishCommandTest extends TestCase
     public function test_throw_exception_when_docker_compose_yml_is_not_found()
     {
         $this->expectException(\ErrorException::class);
-        unlink($this->app->basePath('docker-compose.yml'));
+        if (file_exists($this->app->basePath('docker-compose.yml'))) {
+            unlink($this->app->basePath('docker-compose.yml'));
+        } else if (file_exists($this->app->basePath('compose.yaml'))) {
+            unlink($this->app->basePath('compose.yaml'));
+        }
         $this->artisan('sail-ssl:publish')->assertFailed();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,6 +44,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
         unlink($this->app->basePath('phpunit.xml'));
         if (file_exists($this->app->basePath('docker-compose.yml'))) {
             unlink($this->app->basePath('docker-compose.yml'));
+        } else if (file_exists($this->app->basePath('compose.yaml'))) {
+            unlink($this->app->basePath('compose.yaml'));
         }
         if (file_exists($this->app->basePath('nginx/templates/default.conf.template'))) {
             unlink($this->app->basePath('nginx/templates/default.conf.template'));


### PR DESCRIPTION
Latest version of Sail v1.46.0 has adopted the latest naming convention of docker-compose.yml to compose.yaml.
https://github.com/laravel/sail/releases/tag/v1.46.0

Updated commands to seek both docker-compose and compose for backwards compatibility, and test coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryoluo/sail-ssl/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
